### PR TITLE
Update Wetland Rice to Rice for FAO

### DIFF
--- a/GAEZ_Processing/Crop_code.csv
+++ b/GAEZ_Processing/Crop_code.csv
@@ -51,7 +51,7 @@ TOM,Tomatoes,Tomato
 TOB,Unmanufactured tobacco,Tobacco
 VEG,Vegetables,Vegetables
 TEF,Warm C4,Warm C4
-RCP,Wetland rice,Wetland rice
+RCP,Rice,Wetland rice
 WHE,Wheat,Wheat
 YAM,Yams,Yam
 MLT,Millet,Millet


### PR DESCRIPTION
FAO uses Rice for the crop area harvested but GAEZ uses Wetland Rice.  Fixed this so rice can be included in the summary tables.